### PR TITLE
修复欧陆词典的cookie校验问题

### DIFF
--- a/addon/dictionary/eudict.py
+++ b/addon/dictionary/eudict.py
@@ -44,7 +44,7 @@ class Eudict(AbstractDictionary):
 
     @staticmethod
     def loginCheckCallbackFn(cookie, content):
-        if 'EudicWeb' in cookie:
+        if 'EudicWebSession' in cookie:
             return True
         return False
 


### PR DESCRIPTION
- 使用`EudicWebSession`来判断cookie是否有效