### PR TITLE
fix audio error

### DIFF
--- a/addon/workers.py
+++ b/addon/workers.py
@@ -7,7 +7,8 @@ from .misc import ThreadPool
 from requests.adapters import HTTPAdapter
 from .constants import VERSION, VERSION_CHECK_API
 from PyQt5.QtCore import QObject, pyqtSignal, QThread
-
+import aqt
+import os
 
 class VersionCheckWorker(QObject):
     haveNewVersion = pyqtSignal(str, str)
@@ -150,6 +151,9 @@ class AudioDownloadWorker(QObject):
                         if chunk:
                             f.write(chunk)
                 self.logger.info(f'{fileName} 下载完成')
+                aqt.mw.col.media.add_file(fileName)
+                os.remove(fileName)
+                self.logger.info(f"{fileName} 添加到媒体库,临时文件已删除")
             except Exception as e:
                 self.logger.warning(f'下载{fileName}:{url}异常: {e}')
             finally:


### PR DESCRIPTION
## 问题：

同步后无法在卡片中读到音频，提示音频不存在。

## 环境

在anki for windows 2.1.61 Qt5版本

## 问题原因分析：

`AudioDownloadWorker`将音频下载到anki的安装目录，并未导入anki的媒体文件夹。

## 修复方案：

使用 `aqt.mw.col.media.add_file` 添加音频到媒体文件夹

